### PR TITLE
Define F_GETFD and F_SETFD

### DIFF
--- a/src/flag.rs
+++ b/src/flag.rs
@@ -11,8 +11,10 @@ pub const EVENT_NONE: usize = 0;
 pub const EVENT_READ: usize = 1;
 pub const EVENT_WRITE: usize = 2;
 
-pub const F_GETFL: usize = 1;
-pub const F_SETFL: usize = 2;
+pub const F_GETFD: usize = 1;
+pub const F_SETFD: usize = 2;
+pub const F_GETFL: usize = 3;
+pub const F_SETFL: usize = 4;
 
 pub const FUTEX_WAIT: usize = 0;
 pub const FUTEX_WAKE: usize = 1;


### PR DESCRIPTION
This is a breaking change since `F_GETFL` and `F_SETFL` change value to the same as used under linux, and I think their usual values. It's not really vital, but I think it's probably better.