### PR TITLE
x86_64 instruction change from int 0x80 to syscall

### DIFF
--- a/src/arch/x86_64.rs
+++ b/src/arch/x86_64.rs
@@ -1,7 +1,7 @@
 use super::error::{Error, Result};
 
 pub unsafe fn syscall0(mut a: usize) -> Result<usize> {
-    asm!("int 0x80"
+    asm!("syscall"
         : "={rax}"(a)
         : "{rax}"(a)
         : "memory"
@@ -11,9 +11,9 @@ pub unsafe fn syscall0(mut a: usize) -> Result<usize> {
 }
 
 pub unsafe fn syscall1(mut a: usize, b: usize) -> Result<usize> {
-    asm!("int 0x80"
+    asm!("syscall"
         : "={rax}"(a)
-        : "{rax}"(a), "{rbx}"(b)
+        : "{rax}"(a), "{rdi}"(b)
         : "memory"
         : "intel", "volatile");
 
@@ -22,9 +22,9 @@ pub unsafe fn syscall1(mut a: usize, b: usize) -> Result<usize> {
 
 // Clobbers all registers - special for clone
 pub unsafe fn syscall1_clobber(mut a: usize, b: usize) -> Result<usize> {
-    asm!("int 0x80"
+    asm!("syscall"
         : "={rax}"(a)
-        : "{rax}"(a), "{rbx}"(b)
+        : "{rax}"(a), "{rdi}"(b)
         : "memory", "rbx", "rcx", "rdx", "rsi", "rdi", "r8",
           "r9", "r10", "r11", "r12", "r13", "r14", "r15"
         : "intel", "volatile");
@@ -33,9 +33,9 @@ pub unsafe fn syscall1_clobber(mut a: usize, b: usize) -> Result<usize> {
 }
 
 pub unsafe fn syscall2(mut a: usize, b: usize, c: usize) -> Result<usize> {
-    asm!("int 0x80"
+    asm!("syscall"
         : "={rax}"(a)
-        : "{rax}"(a), "{rbx}"(b), "{rcx}"(c)
+        : "{rax}"(a), "{rdi}"(b), "{rsi}"(c)
         : "memory"
         : "intel", "volatile");
 
@@ -43,9 +43,9 @@ pub unsafe fn syscall2(mut a: usize, b: usize, c: usize) -> Result<usize> {
 }
 
 pub unsafe fn syscall3(mut a: usize, b: usize, c: usize, d: usize) -> Result<usize> {
-    asm!("int 0x80"
+    asm!("syscall"
         : "={rax}"(a)
-        : "{rax}"(a), "{rbx}"(b), "{rcx}"(c), "{rdx}"(d)
+        : "{rax}"(a), "{rdi}"(b), "{rsi}"(c), "{rdx}"(d)
         : "memory"
         : "intel", "volatile");
 
@@ -53,9 +53,9 @@ pub unsafe fn syscall3(mut a: usize, b: usize, c: usize, d: usize) -> Result<usi
 }
 
 pub unsafe fn syscall4(mut a: usize, b: usize, c: usize, d: usize, e: usize) -> Result<usize> {
-    asm!("int 0x80"
+    asm!("syscall"
         : "={rax}"(a)
-        : "{rax}"(a), "{rbx}"(b), "{rcx}"(c), "{rdx}"(d), "{rsi}"(e)
+        : "{rax}"(a), "{rdi}"(b), "{rsi}"(c), "{rdx}"(d), "{r10}"(e)
         : "memory"
         : "intel", "volatile");
 
@@ -66,7 +66,7 @@ pub unsafe fn syscall5(mut a: usize, b: usize, c: usize, d: usize, e: usize, f: 
                        -> Result<usize> {
     asm!("int 0x80"
         : "={rax}"(a)
-        : "{rax}"(a), "{rbx}"(b), "{rcx}"(c), "{rdx}"(d), "{rsi}"(e), "{rdi}"(f)
+        : "{rax}"(a), "{rdi}"(b), "{rsi}"(c), "{rdx}"(d), "{r10}"(e), "{r8}"(f)
         : "memory"
         : "intel", "volatile");
 


### PR DESCRIPTION
It is prefered to use 'syscall' instruction in x86_64 architecture.
I replaced to syscall instruction along with below reference.
[https://en.wikibooks.org/wiki/X86_Assembly/Interfacing_with_Linux](https://en.wikibooks.org/wiki/X86_Assembly/Interfacing_with_Linux)