### PR TITLE
Remove core_intrinsics feature

### DIFF
--- a/src/io/mmio.rs
+++ b/src/io/mmio.rs
@@ -1,4 +1,4 @@
-use core::intrinsics::{volatile_load, volatile_store};
+use core::ptr::{read_volatile, write_volatile};
 use core::mem::uninitialized;
 use core::ops::{BitAnd, BitOr, Not};
 
@@ -22,10 +22,10 @@ impl<T> Io for Mmio<T> where T: Copy + PartialEq + BitAnd<Output = T> + BitOr<Ou
     type Value = T;
 
     fn read(&self) -> T {
-        unsafe { volatile_load(&self.value) }
+        unsafe { read_volatile(&self.value) }
     }
 
     fn write(&mut self, value: T) {
-        unsafe { volatile_store(&mut self.value, value) };
+        unsafe { write_volatile(&mut self.value, value) };
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![deny(warnings)]
 #![feature(asm)]
 #![feature(const_fn)]
-#![feature(core_intrinsics)]
 #![no_std]
 
 pub use self::arch::*;


### PR DESCRIPTION
Stable versions of these functions now exist under core::ptr, so use
those.